### PR TITLE
feat: add support for using `DataSource` and `EntityManager` with transactional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.2
+
+- Feature: add support for using `DataSource` and `EntityManager` with transactional [#2](https://github.com/Aliheym/typeorm-transactional/issues/2)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A `Transactional` Method Decorator for [typeorm](http://typeorm.io/) that uses [cls-hooked](https://www.npmjs.com/package/cls-hooked) to handle and propagate transactions between different repositories and service methods.
 
+See [Changelog](#CHANGELOG.md)
+
 - [Typeorm Transactional](#typeorm-transactional)
   - [Installation](#installation)
   - [Initialization](#initialization)
@@ -178,6 +180,23 @@ export class PostService {
 }
 ```
 
+You can also use `DataSource`/`EntityManager` objects together with repositories in transactions:
+
+```typescript
+export class PostService {
+  constructor(readonly repository: PostRepository, readonly dataSource: DataSource)
+
+  @Transactional() // Will open a transaction if one doesn't already exist
+  async createAndGetPost(id, message): Promise<Post> {
+    const post = this.repository.create({ id, message })
+
+    await this.repository.save(post)
+
+    return dataSource.createQueryBuilder(Post, 'p').where('id = :id', id).getOne();
+  }
+}
+```
+
 ## Data Sources
 
 In new versions of `TypeORM` the `name` property in `Connection` / `DataSource` is deprecated, so to work conveniently with multiple `DataSource` the function  `addTransactionalDataSource` allows you to specify custom the name:
@@ -232,12 +251,12 @@ The following isolation level options can be specified:
 
 ## Hooks
 
-Because you hand over control of the transaction creation to this library, there is no way for you to know whether or not the current transaction was sucessfully persisted to the database.
+Because you hand over control of the transaction creation to this library, there is no way for you to know whether or not the current transaction was successfully persisted to the database.
 
 To circumvent that, we expose three helper methods that allow you to hook into the transaction lifecycle and take appropriate action after a commit/rollback.
 
-- `runOnTransactionCommit(cb)` takes a callback to be executed after the current transaction was sucessfully committed
-- `runOnTransactionRollback(cb)` takes a callback to be executed after the current transaction rolls back. The callback gets the error that initiated the roolback as a parameter.
+- `runOnTransactionCommit(cb)` takes a callback to be executed after the current transaction was successfully committed
+- `runOnTransactionRollback(cb)` takes a callback to be executed after the current transaction rolls back. The callback gets the error that initiated the rollback as a parameter.
 - `runOnTransactionComplete(cb)` takes a callback to be executed at the completion of the current transactional context. If there was an error, it gets passed as an argument.
 
 
@@ -284,7 +303,7 @@ Repositories, services, etc. can be mocked as usual.
 
 - `connectionName`-  DataSource` name to use for this transactional context  ([the data sources](#data-sources))
 - `isolationLevel`- isolation level for transactional context ([isolation levels](#isolation-levels) )
-- `propagation`-  propagation behaviours for nest transactional contexts ([propagation behaviours](#transaction-propagation))
+- `propagation`-  propagation behaviors for nest transactional contexts ([propagation behaviors](#transaction-propagation))
 
 ### initializeTransactionalContext(): void
 
@@ -301,7 +320,7 @@ Add TypeORM `DataSource` to transactional context.
 ```typescript
 addTransactionalDataSource(new DataSource(...));
 
-addTransactionalDataSource({ name: 'default', dataSource: new DataSource(...) });
+addTransactionalDataSource({ name: 'default', dataSource: new DataSource(...), patch: true });
 ```
 
 ### runInTransaction(fn: Callback, options?: Options): Promise<...>
@@ -346,7 +365,7 @@ await updateUser();
 
 ### runOnTransactionCommit(cb: Callback): void
 
-Takes a callback to be executed after the current transaction was sucessfully committed
+Takes a callback to be executed after the current transaction was successfully committed
 
 ```typescript
   @Transactional()
@@ -362,7 +381,7 @@ Takes a callback to be executed after the current transaction was sucessfully co
 
 ### runOnTransactionRollback(cb: Callback): void
 
-Takes a callback to be executed after the current transaction rolls back. The callback gets the error that initiated the roolback as a parameter.
+Takes a callback to be executed after the current transaction rolls back. The callback gets the error that initiated the rollback as a parameter.
 
 ```typescript
   @Transactional()

--- a/src/errors/typeorm-updated-patch.ts
+++ b/src/errors/typeorm-updated-patch.ts
@@ -1,0 +1,9 @@
+export class TypeOrmUpdatedPatchError extends Error {
+  public name = 'TypeOrmUpdatedPatchError';
+
+  constructor() {
+    super(
+      'It seems that TypeORM was updated. Patching "DataSource" is not safe. If you want to try to use the library, set the "patch" flag in the function "addTransactionalDataSource" to "false".',
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { initializeTransactionalContext, addTransactionalDataSource } from './common';
+export {
+  initializeTransactionalContext,
+  addTransactionalDataSource,
+  getDataSourceByName,
+} from './common';
 export {
   runOnTransactionCommit,
   runOnTransactionRollback,

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -1,4 +1,4 @@
-import { DataSource } from 'typeorm';
+import { DataSource, QueryBuilder } from 'typeorm';
 import { Post } from './entities/Post.entity';
 import {
   addTransactionalDataSource,
@@ -16,8 +16,56 @@ async function sleep(ms: number) {
 
 const message = 'a simple message';
 
+interface IQueryable {
+  query(query: string, parameters?: string[]): Promise<unknown>;
+}
+
 describe('Common tests', () => {
   let dataSource: DataSource;
+  let nonPatchedDataSource: DataSource;
+
+  async function isQueryTransactionActive(queryable: IQueryable) {
+    await queryable.query('DELETE FROM "posts" WHERE 1 = 1');
+
+    await queryable.query('INSERT INTO "posts" ("message") VALUES ($1)', [message]);
+
+    const [result] = (await queryable.query(
+      'SELECT txid_current_if_assigned() IS NOT NULL AS is_transaction',
+    )) as [{ is_transaction: boolean }];
+
+    await queryable.query('DELETE FROM "posts" WHERE 1 = 1');
+
+    return result?.is_transaction || false;
+  }
+
+  async function isQueryBuilderWithoutEntityTransactionActive(queryBuilder: QueryBuilder<Post>) {
+    await queryBuilder.delete().where('1 = 1').execute();
+
+    await queryBuilder.insert().values({ message }).execute();
+
+    const result = (await queryBuilder
+      .select('txid_current_if_assigned() is not null', 'is_transaction')
+      .getRawOne()) as { is_transaction: boolean };
+
+    await queryBuilder.delete().where('1 = 1').execute();
+
+    return result?.is_transaction || false;
+  }
+
+  async function isQueryBuilderWithEntityTransactionActive(queryBuilder: QueryBuilder<unknown>) {
+    await queryBuilder.delete().from(Post).where('1 = 1').execute();
+
+    await queryBuilder.insert().into(Post).values({ message }).execute();
+
+    const result = (await queryBuilder
+      .select('txid_current_if_assigned() is not null', 'is_transaction')
+      .from(Post, 'p')
+      .getRawOne()) as { is_transaction: boolean };
+
+    await queryBuilder.delete().from(Post).execute();
+
+    return result?.is_transaction || false;
+  }
 
   beforeAll(async () => {
     dataSource = new DataSource({
@@ -31,20 +79,41 @@ describe('Common tests', () => {
       synchronize: true,
     });
 
+    nonPatchedDataSource = new DataSource({
+      type: 'postgres',
+      host: 'localhost',
+      port: 5435,
+      username: 'postgres',
+      password: 'postgres',
+      database: 'test',
+      entities: [Post],
+      synchronize: true,
+    });
+
     initializeTransactionalContext();
+
     addTransactionalDataSource(dataSource);
+    addTransactionalDataSource({
+      name: 'non-patched',
+      dataSource: nonPatchedDataSource,
+      patch: false,
+    });
 
     await dataSource.initialize();
+    await nonPatchedDataSource.initialize();
 
     await dataSource.createEntityManager().clear(Post);
+    await nonPatchedDataSource.createEntityManager().clear(Post);
   });
 
   afterEach(async () => {
     await dataSource.createEntityManager().clear(Post);
+    await nonPatchedDataSource.createEntityManager().clear(Post);
   });
 
   afterAll(async () => {
     await dataSource.destroy();
+    await nonPatchedDataSource.destroy();
   });
 
   it("shouldn't get post using standard typeorm transaction", async () => {
@@ -231,5 +300,120 @@ describe('Common tests', () => {
 
     expect(writtenPost.id).toBeGreaterThan(0);
     expect(readPost).toBeNull();
+  });
+
+  it("shouldn't be transaction using standard typeorm transaction and DataSource", async () => {
+    let isActive = false;
+
+    await dataSource.transaction(async () => {
+      await isQueryTransactionActive(dataSource);
+    });
+
+    expect(isActive).toBeFalsy();
+  });
+
+  it("shouldn't be transaction outside using runInTransaction and DataSource", async () => {
+    let isActive: boolean = false;
+
+    await runInTransaction(async () => {
+      await isQueryTransactionActive(dataSource);
+    });
+
+    isActive = await isQueryTransactionActive(dataSource);
+
+    expect(isActive).toBeFalsy();
+  });
+
+  it('should be transaction using runInTransaction and DataSource', async () => {
+    let isActive: boolean = false;
+
+    await runInTransaction(async () => {
+      isActive = await isQueryTransactionActive(dataSource);
+    });
+
+    expect(isActive).toBeTruthy();
+  });
+
+  it('should be transaction using runInTransaction and DataSource.manager', async () => {
+    let isActive: boolean = false;
+
+    await runInTransaction(async () => {
+      isActive = await isQueryTransactionActive(dataSource.manager);
+    });
+
+    expect(isActive).toBeTruthy();
+  });
+
+  it('should be transaction using runInTransaction and DataSource.getRepository', async () => {
+    let isActive: boolean = false;
+
+    await runInTransaction(async () => {
+      isActive = await isQueryTransactionActive(dataSource.getRepository(Post));
+    });
+
+    expect(isActive).toBeTruthy();
+  });
+
+  it("shouldn't be transaction using standard typeorm transaction and DataSource.createQueryBuilder", async () => {
+    let isActive = false;
+
+    await dataSource.transaction(async () => {
+      await isQueryBuilderWithoutEntityTransactionActive(dataSource.createQueryBuilder(Post, 'p'));
+    });
+
+    expect(isActive).toBeFalsy();
+  });
+
+  it('should be transaction using runInTransaction and DataSource.createQueryBuilder', async () => {
+    let isActive: boolean = false;
+    let isActiveWithEntity: boolean = false;
+
+    await runInTransaction(async () => {
+      isActive = await isQueryBuilderWithoutEntityTransactionActive(
+        dataSource.createQueryBuilder(Post, 'p'),
+      );
+    });
+
+    await runInTransaction(async () => {
+      isActiveWithEntity = await isQueryBuilderWithEntityTransactionActive(
+        dataSource.createQueryBuilder(),
+      );
+    });
+
+    expect(isActive).toBeTruthy();
+    expect(isActiveWithEntity).toBeTruthy();
+  });
+
+  it('should be transaction using runInTransaction and DataSource.manager.createQueryBuilder', async () => {
+    let isActive: boolean = false;
+    let isActiveWithEntity: boolean = false;
+
+    await runInTransaction(async () => {
+      isActive = await isQueryBuilderWithoutEntityTransactionActive(
+        dataSource.manager.createQueryBuilder(Post, 'p'),
+      );
+    });
+
+    await runInTransaction(async () => {
+      isActiveWithEntity = await isQueryBuilderWithEntityTransactionActive(
+        dataSource.createQueryBuilder(),
+      );
+    });
+
+    expect(isActive).toBeTruthy();
+    expect(isActiveWithEntity).toBeTruthy();
+  });
+
+  it("shouldn't be transaction using runInTransaction and non-patched DataSource", async () => {
+    let isActive: boolean = false;
+
+    await runInTransaction(
+      async () => {
+        isActive = await isQueryTransactionActive(nonPatchedDataSource);
+      },
+      { connectionName: 'non-patched' },
+    );
+
+    expect(isActive).toBeFalsy();
   });
 });


### PR DESCRIPTION
- Add possibility to user `DataSource` and `EntityManager` in transactions with this library;

Thanks @Migushthe2nd for issue https://github.com/Aliheym/typeorm-transactional/issues/2.