### PR TITLE
Add method to delete datasource

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -168,6 +168,8 @@ export const addTransactionalDataSource = (input: DataSource | AddTransactionalD
 
 export const getDataSourceByName = (name: DataSourceName) => dataSources.get(name);
 
+export const deleteDataSourceByName = (name: DataSourceName) => dataSources.delete(name);
+
 export const getHookInContext = (context: Namespace | undefined) =>
   context?.get(TYPEORM_HOOK_NAME) as EventEmitter | null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
   initializeTransactionalContext,
   addTransactionalDataSource,
   getDataSourceByName,
+  deleteDataSourceByName,
 } from './common';
 export {
   runOnTransactionCommit,


### PR DESCRIPTION
Needed to be able to delete the datasource for hot reloading via webpack to work with nestjs. Thanks for the fork!

example:
```ts
  TypeOrmModule.forRootAsync({
      imports: [ConfigModule],
      inject: [AppConfig],
      useFactory: async (app_config: AppConfig) => app_config.getConnectionOptions(),
      async dataSourceFactory(options) {
        if (!options) {
          throw new Error('Invalid options passed');
        }
        deleteDataSourceByName('default'); // Hot reloading requires we remove the previous patched data source
        return addTransactionalDataSource(new DataSource(options));
      },
    }),
```