### PR TITLE
feat: allow to re-patch DataSource & Repository

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -92,6 +92,7 @@ const patchDataSource = (dataSource: DataSource) => {
   let originalManager = dataSource.manager;
 
   Object.defineProperty(dataSource, 'manager', {
+    configurable: true,
     get() {
       return (
         getEntityManagerInContext(this[TYPEORM_DATA_SOURCE_NAME] as DataSourceName) ||
@@ -147,6 +148,7 @@ export const initializeTransactionalContext = (options?: Partial<TypeormTransact
 
   const patchManager = (repositoryType: unknown) => {
     Object.defineProperty(repositoryType, 'manager', {
+      configurable: true,
       get() {
         return (
           getEntityManagerInContext(


### PR DESCRIPTION
In addition to using transactions or not, there's an opportunity to use a similar decorator pattern to switch between databases for read operations like `@ReadReplica()` for example.

In `typeorm-transactional-cls-hooked`, the patch process was called as `patchTypeORMRepositoryWithBaseRepository()`, so instead of calling it, we could use our own patch process that includes patches by the library.

However, `typeorm-transactional` does not work this way because the patching process is called in `initializeTransactionalContext()`.

It may not be the best way, but we can avoid this by allowing `defineProperty` to be called again, and there seems no downside to doing so.