### PR TITLE
chore: addTransactionalDataSource param s order change

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -193,7 +193,7 @@ export const initializeTransactionalContext = (options?: Partial<TypeormTransact
   return createNamespace(NAMESPACE_NAME) || getNamespace(NAMESPACE_NAME);
 };
 
-export const addTransactionalDataSource = (input: DataSource | AddTransactionalDataSourceInput) => {
+export const addTransactionalDataSource = (input: AddTransactionalDataSourceInput | DataSource) => {
   if (isDataSource(input)) {
     input = { name: 'default', dataSource: input, patch: true };
   }


### PR DESCRIPTION
Hello,

i m  back-end developer in south korea. 

i m not good at english , sorry :)

Thank you always

i met this tiny problem when i handled two datasource.

![image](https://user-images.githubusercontent.com/56504493/213166347-54350f0a-0387-4390-b99c-7673fb728e3c.png)

so i must do this

first datasource.
```ts
...
return addTransactionalDataSource(new DataSource(options))
```

and

second datasource.

![image](https://user-images.githubusercontent.com/56504493/213166500-8b025590-528f-41f1-8b86-f1b72da90911.png)


look at this. 'name' property deprecated

because , my IDE infer 'name's type to Datasource in typeorm 'name'

![image](https://user-images.githubusercontent.com/56504493/213166942-3a1837d4-c301-4284-91b0-1159e10b0188.png)

Two simple solutions to a trivial problem.

One is 
**export** interface AddTransactionalDataSourceInput {..}

and the other is

merging this PR .

thank you