### PR TITLE
refactor: remove unnecessary patch

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -173,11 +173,6 @@ export const initializeTransactionalContext = (options?: Partial<TypeormTransact
          * Store current manager
          */
         repository[TYPEORM_ENTITY_MANAGER_NAME] = repository.manager;
-
-        /**
-         * Patch repository object
-         */
-        patchManager(repository);
       }
 
       return repository;


### PR DESCRIPTION
as `patchManager` is called for `Repository.prototype`, there seems no need to call `patchManager` for the specific repository instance.

BTW, it'd be nice to publish new version to include #23 and this (if merged).