### PR TITLE
feat: export getTransactionalContext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   addTransactionalDataSource,
   getDataSourceByName,
   deleteDataSourceByName,
+  getTransactionalContext,
 } from './common';
 export {
   runOnTransactionCommit,


### PR DESCRIPTION
There are situations where the users want to use `getTransactionalContext`, such as before using `initializeTransactionalContext`.   
https://github.com/Aliheym/typeorm-transactional/issues/26#issuecomment-1576189374

I thought `getTransactionalContext` should be exported.

Please merge this if you like.  
thank you.