### PR TITLE
Improve async callbacks handling in hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm-transactional",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm-transactional",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@types/cls-hooked": "^4.3.3",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -25,32 +25,33 @@ export const runAndTriggerHooks = async (hook: EventEmitter, cb: () => unknown) 
 
     // Store the promises returned by commit handlers
     const commitPromises: Promise<unknown>[] = [];
-    
+
+    // promiseCollector is an internal callback emitted with each event.
+    // This acts as a channel between the receiver (.once() listener) to send
+    // promises back to the emitter.
+    const promiseCollector = (promise: Promise<unknown>) => {
+      commitPromises.push(promise);
+    };
+
     // Create a promise that will be resolved when all commit handlers are executed
     const commitPromise = new Promise<void>((resolve) => {
       setImmediate(() => {
         // Emit the 'commit' event and collect promises
-        hook.emit('commit', (promise: Promise<unknown>) => {
-          if (promise && typeof promise.then === 'function') {
-            commitPromises.push(promise);
-          }
-        });
-        
+        hook.emit('commit', promiseCollector);
+
         // Once all handlers have been called, resolve the promise
-        Promise.all(commitPromises)
-          .catch(error => console.error('Error in commit handler:', error))
-          .finally(() => {
-            // Always clean up after commit handlers, regardless of success/failure
-            hook.emit('end', undefined);
-            hook.removeAllListeners();
-            resolve();
-          });
+        Promise.all(commitPromises).finally(() => {
+          // Always clean up after commit handlers, regardless of success/failure
+          hook.emit('end', undefined);
+          hook.removeAllListeners();
+          resolve();
+        });
       });
     });
-    
+
     // Wait for all commit handlers to complete
     await commitPromise;
-    
+
     return result;
   } catch (err) {
     setImmediate(() => {
@@ -64,7 +65,7 @@ export const runAndTriggerHooks = async (hook: EventEmitter, cb: () => unknown) 
   }
 };
 
-export const createEventEmitterInNewContext = (context: StorageDriver) => {
+export const createEventEmitterInNewContext = () => {
   const options = getTransactionalOptions();
 
   const emitter = new EventEmitter();
@@ -73,7 +74,7 @@ export const createEventEmitterInNewContext = (context: StorageDriver) => {
 };
 
 export const runInNewHookContext = async (context: StorageDriver, cb: () => unknown) => {
-  const hook = createEventEmitterInNewContext(context);
+  const hook = createEventEmitterInNewContext();
 
   return await context.run(() => {
     setHookInContext(context, hook);
@@ -83,13 +84,17 @@ export const runInNewHookContext = async (context: StorageDriver, cb: () => unkn
 };
 
 export const runOnTransactionCommit = (cb: () => void | Promise<unknown>) => {
-  getTransactionalContextHook().once('commit', (collectPromise?: (promise: Promise<unknown>) => void) => {
-    const result = cb();
-    if (result && typeof result.then === 'function' && collectPromise) {
-      collectPromise(result);
-    }
-    return result;
-  });
+  getTransactionalContextHook().once(
+    'commit',
+    (promiseCollector: (promise: Promise<unknown>) => void) => {
+      const result = cb();
+      // If the original callback returns a promise, we need to collect it
+      if (result && typeof result.then === 'function') {
+        promiseCollector(result);
+      }
+      return result;
+    },
+  );
 };
 
 export const runOnTransactionRollback = (cb: (e: Error) => void) => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -34,18 +34,22 @@ export const runAndTriggerHooks = async (hook: EventEmitter, cb: () => unknown) 
     };
 
     // Create a promise that will be resolved when all commit handlers are executed
-    const commitPromise = new Promise<void>((resolve) => {
+    const commitPromise = new Promise<void>((resolve, reject) => {
       setImmediate(() => {
         // Emit the 'commit' event and collect promises
         hook.emit('commit', promiseCollector);
 
         // Once all handlers have been called, resolve the promise
-        Promise.all(commitPromises).finally(() => {
-          // Always clean up after commit handlers, regardless of success/failure
-          hook.emit('end', undefined);
-          hook.removeAllListeners();
-          resolve();
-        });
+        Promise.all(commitPromises)
+          .then(() => resolve())
+          .catch((err) => {
+            reject(err);
+          })
+          .finally(() => {
+            // Always clean up after commit handlers, regardless of success/failure
+            hook.emit('end', undefined);
+            hook.removeAllListeners();
+          });
       });
     });
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -23,13 +23,34 @@ export const runAndTriggerHooks = async (hook: EventEmitter, cb: () => unknown) 
   try {
     const result = await Promise.resolve(cb());
 
-    setImmediate(() => {
-      hook.emit('commit');
-
-      hook.emit('end', undefined);
-      hook.removeAllListeners();
+    // Store the promises returned by commit handlers
+    const commitPromises: Promise<unknown>[] = [];
+    
+    // Create a promise that will be resolved when all commit handlers are executed
+    const commitPromise = new Promise<void>((resolve) => {
+      setImmediate(() => {
+        // Emit the 'commit' event and collect promises
+        hook.emit('commit', (promise: Promise<unknown>) => {
+          if (promise && typeof promise.then === 'function') {
+            commitPromises.push(promise);
+          }
+        });
+        
+        // Once all handlers have been called, resolve the promise
+        Promise.all(commitPromises)
+          .catch(error => console.error('Error in commit handler:', error))
+          .finally(() => {
+            // Always clean up after commit handlers, regardless of success/failure
+            hook.emit('end', undefined);
+            hook.removeAllListeners();
+            resolve();
+          });
+      });
     });
-
+    
+    // Wait for all commit handlers to complete
+    await commitPromise;
+    
     return result;
   } catch (err) {
     setImmediate(() => {
@@ -61,8 +82,14 @@ export const runInNewHookContext = async (context: StorageDriver, cb: () => unkn
   });
 };
 
-export const runOnTransactionCommit = (cb: () => void) => {
-  getTransactionalContextHook().once('commit', cb);
+export const runOnTransactionCommit = (cb: () => void | Promise<unknown>) => {
+  getTransactionalContextHook().once('commit', (collectPromise?: (promise: Promise<unknown>) => void) => {
+    const result = cb();
+    if (result && typeof result.then === 'function' && collectPromise) {
+      collectPromise(result);
+    }
+    return result;
+  });
 };
 
 export const runOnTransactionRollback = (cb: (e: Error) => void) => {

--- a/src/transactions/wrap-in-transaction.ts
+++ b/src/transactions/wrap-in-transaction.ts
@@ -25,7 +25,7 @@ export interface WrapInTransactionOptions {
   name?: string | symbol;
 }
 
-export const wrapInTransaction = <Fn extends (this: any, ...args: any[]) => ReturnType<Fn>>(
+export const wrapInTransaction = <Fn extends (this: unknown, ...args: unknown[]) => ReturnType<Fn>>(
   fn: Fn,
   options?: WrapInTransactionOptions,
 ) => {

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -98,205 +98,28 @@ describe('Transactional', () => {
         });
 
         const transactionIdOutside = await getCurrentTransactionId(source);
-        expect(transactionIdOutside).toBe(null);
-        expect(transactionIdOutside).not.toBe(transactionIdBefore);
-      });
-
-      it('supports nested transactions', async () => {
-        await runInTransaction(async () => {
-          const transactionIdBefore = await getCurrentTransactionId(source);
-
-          await runInTransaction(async () => {
-            const transactionIdAfter = await getCurrentTransactionId(source);
-            expect(transactionIdBefore).toBe(transactionIdAfter);
-          });
-        });
-
-        expect.assertions(1);
-      });
-
-      it('supports several concurrent transactions', async () => {
-        let transactionA: number | null = null;
-        let transactionB: number | null = null;
-        let transactionC: number | null = null;
-
-        await Promise.all([
-          runInTransaction(async () => {
-            transactionA = await getCurrentTransactionId(source);
-          }),
-          runInTransaction(async () => {
-            transactionB = await getCurrentTransactionId(source);
-          }),
-          runInTransaction(async () => {
-            transactionC = await getCurrentTransactionId(source);
-          }),
-        ]);
-
-        await Promise.all([transactionA, transactionB, transactionC]);
-
-        expect(transactionA).toBeTruthy();
-        expect(transactionB).toBeTruthy();
-        expect(transactionC).toBeTruthy();
-
-        expect(transactionA).not.toBe(transactionB);
-        expect(transactionA).not.toBe(transactionC);
-        expect(transactionB).not.toBe(transactionC);
-      });
-    });
-
-    // We want to check that `save` doesn't create any intermediate transactions
-    describe('Repository', () => {
-      it('should not create any intermediate transactions', async () => {
-        let transactionIdA: number | null = null;
-        let transactionIdB: number | null = null;
-
-        const userRepository = dataSource.getRepository(User);
-
-        await runInTransaction(async () => {
-          transactionIdA = await getCurrentTransactionId(dataSource);
-          await userRepository.save(new User('John Doe', 100));
-        });
-
-        await runInTransaction(async () => {
-          transactionIdB = await getCurrentTransactionId(dataSource);
-        });
-
-        let transactionDiff = transactionIdB! - transactionIdA!;
-        expect(transactionDiff).toBe(1);
-      });
-    });
-
-    describe('Extend Repository', () => {
-      it('should not create any intermediate transactions', async () => {
-        let transactionIdA: number | null = null;
-        let transactionIdB: number | null = null;
-
-        const customRepository = extendUserRepository(dataSource.getRepository(User));
-
-        await runInTransaction(async () => {
-          transactionIdA = await getCurrentTransactionId(dataSource);
-          await customRepository.save(new User('John Doe', 100));
-        });
-
-        await runInTransaction(async () => {
-          transactionIdB = await getCurrentTransactionId(dataSource);
-        });
-
-        let transactionDiff = transactionIdB! - transactionIdA!;
-        expect(transactionDiff).toBe(1);
-      });
-    });
-
-    // describe('Query Builder', () => {
-    //   it('should not create any intermediate transactions', async () => {
-    //     let transactionIdA: number | null = null;
-    //     let transactionIdB: number | null = null;
-
-    //     const qb = dataSource.createQueryBuilder();
-
-    //     await runInTransaction(async () => {
-    //       transactionIdA = await getCurrentTransactionId(dataSource);
-    //       await qb.insert().into(User).values({ name: 'John Doe', money: 100 }).execute();
-    //     });
-
-    //     await runInTransaction(async () => {
-    //       transactionIdB = await getCurrentTransactionId(dataSource);
-    //     });
-
-    //     let transactionDiff = transactionIdB! - transactionIdA!;
-    //     expect(transactionDiff).toBe(1);
-    //   });
-    // });
-
-    // describe('Entity Manager', () => {
-    //   it('should not create any intermediate transactions', async () => {
-    //     let transactionIdA: number | null = null;
-    //     let transactionIdB: number | null = null;
-
-    //     await runInTransaction(async () => {
-    //       transactionIdA = await getCurrentTransactionId(dataSource);
-    //       await dataSource.createEntityManager().save(new User('John Doe', 100));
-    //     });
-
-    //     await runInTransaction(async () => {
-    //       transactionIdB = await getCurrentTransactionId(dataSource);
-    //     });
-
-    //     let transactionDiff = transactionIdB! - transactionIdA!;
-    //     expect(transactionDiff).toBe(1);
-    //   });
-    // });
-  });
-
-  // Focus more on the repository, since it's the most common use case
-  describe('Repository', () => {
-    it('supports basic transactions', async () => {
-      const userRepository = new UserRepository(dataSource);
-
-      let transactionIdBefore: number | null = null;
-      await runInTransaction(async () => {
-        transactionIdBefore = await getCurrentTransactionId(userRepository);
-        await userRepository.createUser('John Doe');
-        const transactionIdAfter = await getCurrentTransactionId(userRepository);
 
         expect(transactionIdBefore).toBeTruthy();
-        expect(transactionIdBefore).toBe(transactionIdAfter);
+        expect(transactionIdOutside).toBe(null);
+        expect(transactionIdBefore).not.toBe(transactionIdOutside);
       });
-
-      const transactionIdOutside = await getCurrentTransactionId(userRepository);
-      expect(transactionIdOutside).toBe(null);
-      expect(transactionIdOutside).not.toBe(transactionIdBefore);
-
-      const user = await userRepository.findUserByName('John Doe');
-      expect(user).toBeDefined();
     });
 
-    it('should rollback the transaction if an error is thrown', async () => {
-      const userRepository = new UserRepository(dataSource);
-
-      try {
-        await runInTransaction(async () => {
-          await userRepository.createUser('John Doe');
-
-          throw new Error('Rollback transaction');
-        });
-      } catch {}
-
-      const user = await userRepository.findUserByName('John Doe');
-      expect(user).toBe(null);
-    });
-
-    it('supports nested transactions', async () => {
-      const userRepository = new UserRepository(dataSource);
-
-      await runInTransaction(async () => {
-        const transactionIdBefore = await getCurrentTransactionId(userRepository);
-        await userRepository.createUser('John Doe');
-
-        await runInTransaction(async () => {
-          const transactionIdAfter = await getCurrentTransactionId(userRepository);
-          expect(transactionIdBefore).toBe(transactionIdAfter);
-        });
-      });
-
-      expect.assertions(1);
-    });
-
-    it('supports several concurrent transactions', async () => {
-      const userRepository = new UserRepository(dataSource);
-
+    it('supports multiple parallel transaction', async () => {
       let transactionA: number | null = null;
       let transactionB: number | null = null;
       let transactionC: number | null = null;
 
-      await Promise.all([
+      const userRepository = new UserRepository(dataSource);
+
+      const [, ,] = await Promise.all([
         runInTransaction(async () => {
-          userRepository.createUser('John Doe');
+          await userRepository.createUser('John Doe');
 
           transactionA = await getCurrentTransactionId(userRepository);
         }),
         runInTransaction(async () => {
-          userRepository.createUser('Bob Smith');
+          await userRepository.createUser('Jane Smith');
 
           transactionB = await getCurrentTransactionId(userRepository);
         }),
@@ -399,58 +222,6 @@ describe('Transactional', () => {
       });
     });
 
-    it('should support "SUPPORTS" propagation if active transaction exists', async () => {
-      const userRepository = new UserRepository(dataSource);
-
-      await runInTransaction(async () => {
-        const transactionId = await getCurrentTransactionId(userRepository);
-        await userRepository.createUser('John Doe');
-
-        await runInTransaction(
-          async () => {
-            await userRepository.createUser('Bob Smith');
-            const transactionIdNested = await getCurrentTransactionId(userRepository);
-
-            // We expect the nested transaction to be under the same transaction
-            expect(transactionId).toBe(transactionIdNested);
-          },
-          { propagation: Propagation.SUPPORTS },
-        );
-      });
-    });
-
-    it('should support "SUPPORTS" propagation if active transaction doesn\'t exist', async () => {
-      const userRepository = new UserRepository(dataSource);
-
-      await runInTransaction(
-        async () => {
-          const transactionId = await getCurrentTransactionId(userRepository);
-
-          // We expect the code to be executed without a transaction
-          expect(transactionId).toBe(null);
-        },
-        { propagation: Propagation.SUPPORTS },
-      );
-    });
-
-    it('should support "MANDATORY" propagation if active transaction exists', async () => {
-      const userRepository = new UserRepository(dataSource);
-
-      await runInTransaction(async () => {
-        const transactionId = await getCurrentTransactionId(userRepository);
-
-        await runInTransaction(
-          async () => {
-            const transactionIdNested = await getCurrentTransactionId(userRepository);
-
-            // We expect the nested transaction to be under the same transaction
-            expect(transactionId).toBe(transactionIdNested);
-          },
-          { propagation: Propagation.MANDATORY },
-        );
-      });
-    });
-
     it('should throw an error if "MANDATORY" propagation is used without an active transaction', async () => {
       const userRepository = new UserRepository(dataSource);
 
@@ -546,6 +317,59 @@ describe('Transactional', () => {
       expect(commitSpy).toHaveBeenCalledTimes(1);
       expect(rollbackSpy).not.toHaveBeenCalled();
       expect(completeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should run async "runOnTransactionCommit" hook and wait for it to complete', async () => {
+      const userRepository = new UserRepository(dataSource);
+      let asyncOperationComplete = false;
+      
+      await runInTransaction(async () => {
+        await userRepository.createUser('John Doe');
+        
+        runOnTransactionCommit(async () => {
+          await sleep(100);
+          asyncOperationComplete = true;
+        });
+      });
+      
+      // The transaction should have waited for the async hook to complete
+      expect(asyncOperationComplete).toBe(true);
+    });
+
+    it('should run multiple async "runOnTransactionCommit" hooks in parallel', async () => {
+      const userRepository = new UserRepository(dataSource);
+      const results: number[] = [];
+      const start = Date.now();
+      
+      await runInTransaction(async () => {
+        await userRepository.createUser('John Doe');
+        
+        // Add three async hooks that take different times to complete
+        runOnTransactionCommit(async () => {
+          await sleep(100);
+          results.push(1);
+        });
+        
+        runOnTransactionCommit(async () => {
+          await sleep(200);
+          results.push(2);
+        });
+        
+        runOnTransactionCommit(async () => {
+          await sleep(50);
+          results.push(3);
+        });
+      });
+      
+      // All hooks should have completed
+      expect(results).toContain(1);
+      expect(results).toContain(2);
+      expect(results).toContain(3);
+      
+      // Total time should be approximately the longest hook (200ms) plus some overhead
+      // Rather than sequential (350ms)
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(300);
     });
 
     it('should run "runOnTransactionRollback" hook', async () => {

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -651,7 +651,6 @@ describe('Transactional', () => {
       // since the side effects are run post commit
       await expect(
         async () => {
-          
           await runInTransaction(async () => {
             await userRepository.createUser('John Doe');
             

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -98,28 +98,205 @@ describe('Transactional', () => {
         });
 
         const transactionIdOutside = await getCurrentTransactionId(source);
-
-        expect(transactionIdBefore).toBeTruthy();
         expect(transactionIdOutside).toBe(null);
-        expect(transactionIdBefore).not.toBe(transactionIdOutside);
+        expect(transactionIdOutside).not.toBe(transactionIdBefore);
+      });
+
+      it('supports nested transactions', async () => {
+        await runInTransaction(async () => {
+          const transactionIdBefore = await getCurrentTransactionId(source);
+
+          await runInTransaction(async () => {
+            const transactionIdAfter = await getCurrentTransactionId(source);
+            expect(transactionIdBefore).toBe(transactionIdAfter);
+          });
+        });
+
+        expect.assertions(1);
+      });
+
+      it('supports several concurrent transactions', async () => {
+        let transactionA: number | null = null;
+        let transactionB: number | null = null;
+        let transactionC: number | null = null;
+
+        await Promise.all([
+          runInTransaction(async () => {
+            transactionA = await getCurrentTransactionId(source);
+          }),
+          runInTransaction(async () => {
+            transactionB = await getCurrentTransactionId(source);
+          }),
+          runInTransaction(async () => {
+            transactionC = await getCurrentTransactionId(source);
+          }),
+        ]);
+
+        await Promise.all([transactionA, transactionB, transactionC]);
+
+        expect(transactionA).toBeTruthy();
+        expect(transactionB).toBeTruthy();
+        expect(transactionC).toBeTruthy();
+
+        expect(transactionA).not.toBe(transactionB);
+        expect(transactionA).not.toBe(transactionC);
+        expect(transactionB).not.toBe(transactionC);
       });
     });
 
-    it('supports multiple parallel transaction', async () => {
+    // We want to check that `save` doesn't create any intermediate transactions
+    describe('Repository', () => {
+      it('should not create any intermediate transactions', async () => {
+        let transactionIdA: number | null = null;
+        let transactionIdB: number | null = null;
+
+        const userRepository = dataSource.getRepository(User);
+
+        await runInTransaction(async () => {
+          transactionIdA = await getCurrentTransactionId(dataSource);
+          await userRepository.save(new User('John Doe', 100));
+        });
+
+        await runInTransaction(async () => {
+          transactionIdB = await getCurrentTransactionId(dataSource);
+        });
+
+        let transactionDiff = transactionIdB! - transactionIdA!;
+        expect(transactionDiff).toBe(1);
+      });
+    });
+
+    describe('Extend Repository', () => {
+      it('should not create any intermediate transactions', async () => {
+        let transactionIdA: number | null = null;
+        let transactionIdB: number | null = null;
+
+        const customRepository = extendUserRepository(dataSource.getRepository(User));
+
+        await runInTransaction(async () => {
+          transactionIdA = await getCurrentTransactionId(dataSource);
+          await customRepository.save(new User('John Doe', 100));
+        });
+
+        await runInTransaction(async () => {
+          transactionIdB = await getCurrentTransactionId(dataSource);
+        });
+
+        let transactionDiff = transactionIdB! - transactionIdA!;
+        expect(transactionDiff).toBe(1);
+      });
+    });
+
+    // describe('Query Builder', () => {
+    //   it('should not create any intermediate transactions', async () => {
+    //     let transactionIdA: number | null = null;
+    //     let transactionIdB: number | null = null;
+
+    //     const qb = dataSource.createQueryBuilder();
+
+    //     await runInTransaction(async () => {
+    //       transactionIdA = await getCurrentTransactionId(dataSource);
+    //       await qb.insert().into(User).values({ name: 'John Doe', money: 100 }).execute();
+    //     });
+
+    //     await runInTransaction(async () => {
+    //       transactionIdB = await getCurrentTransactionId(dataSource);
+    //     });
+
+    //     let transactionDiff = transactionIdB! - transactionIdA!;
+    //     expect(transactionDiff).toBe(1);
+    //   });
+    // });
+
+    // describe('Entity Manager', () => {
+    //   it('should not create any intermediate transactions', async () => {
+    //     let transactionIdA: number | null = null;
+    //     let transactionIdB: number | null = null;
+
+    //     await runInTransaction(async () => {
+    //       transactionIdA = await getCurrentTransactionId(dataSource);
+    //       await dataSource.createEntityManager().save(new User('John Doe', 100));
+    //     });
+
+    //     await runInTransaction(async () => {
+    //       transactionIdB = await getCurrentTransactionId(dataSource);
+    //     });
+
+    //     let transactionDiff = transactionIdB! - transactionIdA!;
+    //     expect(transactionDiff).toBe(1);
+    //   });
+    // });
+  });
+
+  // Focus more on the repository, since it's the most common use case
+  describe('Repository', () => {
+    it('supports basic transactions', async () => {
+      const userRepository = new UserRepository(dataSource);
+
+      let transactionIdBefore: number | null = null;
+      await runInTransaction(async () => {
+        transactionIdBefore = await getCurrentTransactionId(userRepository);
+        await userRepository.createUser('John Doe');
+        const transactionIdAfter = await getCurrentTransactionId(userRepository);
+
+        expect(transactionIdBefore).toBeTruthy();
+        expect(transactionIdBefore).toBe(transactionIdAfter);
+      });
+
+      const transactionIdOutside = await getCurrentTransactionId(userRepository);
+      expect(transactionIdOutside).toBe(null);
+      expect(transactionIdOutside).not.toBe(transactionIdBefore);
+
+      const user = await userRepository.findUserByName('John Doe');
+      expect(user).toBeDefined();
+    });
+
+    it('should rollback the transaction if an error is thrown', async () => {
+      const userRepository = new UserRepository(dataSource);
+
+      try {
+        await runInTransaction(async () => {
+          await userRepository.createUser('John Doe');
+
+          throw new Error('Rollback transaction');
+        });
+      } catch {}
+
+      const user = await userRepository.findUserByName('John Doe');
+      expect(user).toBe(null);
+    });
+
+    it('supports nested transactions', async () => {
+      const userRepository = new UserRepository(dataSource);
+
+      await runInTransaction(async () => {
+        const transactionIdBefore = await getCurrentTransactionId(userRepository);
+        await userRepository.createUser('John Doe');
+
+        await runInTransaction(async () => {
+          const transactionIdAfter = await getCurrentTransactionId(userRepository);
+          expect(transactionIdBefore).toBe(transactionIdAfter);
+        });
+      });
+
+      expect.assertions(1);
+    });
+
+    it('supports several concurrent transactions', async () => {
+      const userRepository = new UserRepository(dataSource);
+
       let transactionA: number | null = null;
       let transactionB: number | null = null;
       let transactionC: number | null = null;
 
-      const userRepository = new UserRepository(dataSource);
-
-      const [, ,] = await Promise.all([
+      await Promise.all([
         runInTransaction(async () => {
-          await userRepository.createUser('John Doe');
+          userRepository.createUser('John Doe');
 
           transactionA = await getCurrentTransactionId(userRepository);
         }),
         runInTransaction(async () => {
-          await userRepository.createUser('Jane Smith');
+          userRepository.createUser('Bob Smith');
 
           transactionB = await getCurrentTransactionId(userRepository);
         }),
@@ -222,6 +399,58 @@ describe('Transactional', () => {
       });
     });
 
+    it('should support "SUPPORTS" propagation if active transaction exists', async () => {
+      const userRepository = new UserRepository(dataSource);
+
+      await runInTransaction(async () => {
+        const transactionId = await getCurrentTransactionId(userRepository);
+        await userRepository.createUser('John Doe');
+
+        await runInTransaction(
+          async () => {
+            await userRepository.createUser('Bob Smith');
+            const transactionIdNested = await getCurrentTransactionId(userRepository);
+
+            // We expect the nested transaction to be under the same transaction
+            expect(transactionId).toBe(transactionIdNested);
+          },
+          { propagation: Propagation.SUPPORTS },
+        );
+      });
+    });
+
+    it('should support "SUPPORTS" propagation if active transaction doesn\'t exist', async () => {
+      const userRepository = new UserRepository(dataSource);
+
+      await runInTransaction(
+        async () => {
+          const transactionId = await getCurrentTransactionId(userRepository);
+
+          // We expect the code to be executed without a transaction
+          expect(transactionId).toBe(null);
+        },
+        { propagation: Propagation.SUPPORTS },
+      );
+    });
+
+    it('should support "MANDATORY" propagation if active transaction exists', async () => {
+      const userRepository = new UserRepository(dataSource);
+
+      await runInTransaction(async () => {
+        const transactionId = await getCurrentTransactionId(userRepository);
+
+        await runInTransaction(
+          async () => {
+            const transactionIdNested = await getCurrentTransactionId(userRepository);
+
+            // We expect the nested transaction to be under the same transaction
+            expect(transactionId).toBe(transactionIdNested);
+          },
+          { propagation: Propagation.MANDATORY },
+        );
+      });
+    });
+
     it('should throw an error if "MANDATORY" propagation is used without an active transaction', async () => {
       const userRepository = new UserRepository(dataSource);
 
@@ -319,59 +548,6 @@ describe('Transactional', () => {
       expect(completeSpy).not.toHaveBeenCalled();
     });
 
-    it('should run async "runOnTransactionCommit" hook and wait for it to complete', async () => {
-      const userRepository = new UserRepository(dataSource);
-      let asyncOperationComplete = false;
-      
-      await runInTransaction(async () => {
-        await userRepository.createUser('John Doe');
-        
-        runOnTransactionCommit(async () => {
-          await sleep(100);
-          asyncOperationComplete = true;
-        });
-      });
-      
-      // The transaction should have waited for the async hook to complete
-      expect(asyncOperationComplete).toBe(true);
-    });
-
-    it('should run multiple async "runOnTransactionCommit" hooks in parallel', async () => {
-      const userRepository = new UserRepository(dataSource);
-      const results: number[] = [];
-      const start = Date.now();
-      
-      await runInTransaction(async () => {
-        await userRepository.createUser('John Doe');
-        
-        // Add three async hooks that take different times to complete
-        runOnTransactionCommit(async () => {
-          await sleep(100);
-          results.push(1);
-        });
-        
-        runOnTransactionCommit(async () => {
-          await sleep(200);
-          results.push(2);
-        });
-        
-        runOnTransactionCommit(async () => {
-          await sleep(50);
-          results.push(3);
-        });
-      });
-      
-      // All hooks should have completed
-      expect(results).toContain(1);
-      expect(results).toContain(2);
-      expect(results).toContain(3);
-      
-      // Total time should be approximately the longest hook (200ms) plus some overhead
-      // Rather than sequential (350ms)
-      const elapsed = Date.now() - start;
-      expect(elapsed).toBeLessThan(300);
-    });
-
     it('should run "runOnTransactionRollback" hook', async () => {
       const userRepository = new UserRepository(dataSource);
       const commitSpy = jest.fn();
@@ -413,6 +589,59 @@ describe('Transactional', () => {
       expect(rollbackSpy).not.toHaveBeenCalled();
       expect(completeSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should run async "runOnTransactionCommit" hook and wait for it to complete', async () => {
+      const userRepository = new UserRepository(dataSource);
+      let asyncOperationComplete = false;
+      
+      await runInTransaction(async () => {
+        await userRepository.createUser('John Doe');
+        
+        runOnTransactionCommit(async () => {
+          await sleep(100);
+          asyncOperationComplete = true;
+        });
+      });
+      
+      // The transaction should have waited for the async hook to complete
+      expect(asyncOperationComplete).toBe(true);
+    });
+  
+    it('should run multiple async "runOnTransactionCommit" hooks in parallel', async () => {
+      const userRepository = new UserRepository(dataSource);
+      const results: number[] = [];
+      const start = Date.now();
+      
+      await runInTransaction(async () => {
+        await userRepository.createUser('John Doe');
+        
+        // Add three async hooks that take different times to complete
+        runOnTransactionCommit(async () => {
+          await sleep(100);
+          results.push(1);
+        });
+        
+        runOnTransactionCommit(async () => {
+          await sleep(200);
+          results.push(2);
+        });
+        
+        runOnTransactionCommit(async () => {
+          await sleep(50);
+          results.push(3);
+        });
+      });
+      
+      // All hooks should have completed
+      expect(results).toContain(1);
+      expect(results).toContain(2);
+      expect(results).toContain(3);
+      
+      // Total time should be approximately the longest hook (200ms) plus some overhead
+      // Rather than sequential (350ms)
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(300);
+    });  
   });
 
   describe('Isolation', () => {

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -642,6 +642,31 @@ describe('Transactional', () => {
       const elapsed = Date.now() - start;
       expect(elapsed).toBeLessThan(300);
     });  
+
+    it('should bubble up rejection from async "runOnTransactionCommit" hook but transaction should commit', async () => {
+      const userRepository = new UserRepository(dataSource);
+      const expectedError = new Error('Async hook error');
+      
+      // Should reject with our hook error but the transaction should still commit
+      // since the side effects are run post commit
+      await expect(
+        async () => {
+          
+          await runInTransaction(async () => {
+            await userRepository.createUser('John Doe');
+            
+            runOnTransactionCommit(async () => {
+              throw expectedError;
+            });
+          })
+
+        }).rejects.toThrow();
+
+      const user = await userRepository.findUserByName('John Doe');
+      expect(user).not.toBeNull();
+      expect(user?.name).toBe('John Doe');
+    });
+
   });
 
   describe('Isolation', () => {


### PR DESCRIPTION
Adds support for `awaiting` async callbacks in on-commit hooks

```js
class UserService {
    async enqueueSignUpEmail(user) {
      await queue.publish(....);
    }
  
    @Transactional
    async createUser(user) {
       const newUser = await this.repo.insert(user);
 
       // Earlier this async side-effect enqueueSignUpEmail was not
       // awaited at any point.
       // Now with the change in this branch, this side-effect is
       // awaited right after commit.

       runOnTransactionCommit(() => this.enqueueSignUpEmail(user));

    }
}
```



@Aliheym thoughts on this?